### PR TITLE
Added payment rejection for Transferuj backend (second attempt).

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -279,6 +279,16 @@ It will produce following example output::
     Please remember to set correct domain name in Sites framework.
 
 
+Payment rejection for Transferuj
+````````````````````````````````
+Transferuj allows to schedule chargeback of payment before it is added to the receiver’s account. To use that functionality, you should use signals::
+
+    def payment_rejection_listener(sender, payment, **kwargs):
+       if my_awesome_payment_rejection_condition(payment):
+           payment.should_be_rejected = True
+
+    signals.payment_rejection_available.connect(payment_rejection_listener)
+
 
 Dotpay.eu backend ``getpaid.backends.dotpay``
 ---------------------------------------------
@@ -338,7 +348,7 @@ Optional keys:
 
 **tax**
     1% charity (refer to Dotpay manual); default: ``False``
-    
+
 
 
 
@@ -446,7 +456,7 @@ Required keys:
 
 **token**
     your seller's account token
-    
+
 **key**
     your secret key
 
@@ -464,8 +474,8 @@ You need to provide this information in ``GETPAID_BACKENDS_SETTINGS`` dictionary
                 'testing': True,
             },
     }
-    
-    
+
+
 Status changes
 `````````````
 Even though Moip has 9 different statuses, this only translates into 3 statuses in `django-getpaid`. Before the payment is made, the initial status is `in_progress`. Once it moves in Moip to the authorized, the getpaid state also changes on this backend to paid. If at any point Moip changes the transaction status to chargeback or refunded, the status on this backend will also enter the failed state. Beware that all others statuses in between are ignored. You will not be notified if a transaction moves from paid to available or if it enters dispute. This should however make no difference, as it only really matters if your transaction at Moip changes from in dispute to refunded or chargedback (and both are tracked).
@@ -487,7 +497,7 @@ Required keys:
 
 **PAYMILL_PUBLIC_KEY**
     your public key
-    
+
 **PAYMILL_PRIVATE_KEY**
     your private key
 
@@ -500,8 +510,8 @@ You need to provide this information in ``GETPAID_BACKENDS_SETTINGS`` dictionary
             'PAYMILL_PRIVATE_KEY': '1b9a36f6g6e2d52aab7858f5a5eb8k67',
         }
     }
-    
-    
+
+
 A word about security
 `````````````````````
 Though we have to display the form for the credit card data on our website, it will never be sent to the server to comply with the `Payment Card Industry Data Security Standard <http://en.wikipedia.org/wiki/Payment_Card_Industry_Data_Security_Standard>`_. Instead, Paymill's JavaScript API is used to generate a token that is sent to the server to process the payment.

--- a/getpaid/signals.py
+++ b/getpaid/signals.py
@@ -32,3 +32,14 @@ redirecting_to_payment_gateway_signal = Signal(providing_args=['request', 'order
 redirecting_to_payment_gateway_signal.__doc__ = """
 Sent just a moment before redirecting. A hook for analytics tools.
 """
+
+payment_rejection_available = Signal(providing_args=['payment'])
+payment_rejection_available.__doc__ = """
+Sent when a decision is to be made whether payment should be rejected.
+
+For a payment to be rejected, the signal listener should set
+``should_be_rejected`` attribute on payment to some value which evaluates to True.
+
+This is a feature specific to Transferuj backend.
+
+"""


### PR DESCRIPTION
This is a special feature specific to Transferuj which allows to charge back
payment before it has been added to the receiver’s account.

A second attempt, this time using signals, according to comment from pull request #40.