### PR TITLE
Add USD to supported currencies in Paymill backend

### DIFF
--- a/getpaid/backends/paymill/__init__.py
+++ b/getpaid/backends/paymill/__init__.py
@@ -6,7 +6,7 @@ class PaymentProcessor(PaymentProcessorBase):
     BACKEND = 'getpaid.backends.paymill'
     BACKEND_NAME = _('Paymill')
     BACKEND_ACCEPTED_CURRENCY = ('EUR', 'CZK', 'DKK', 'HUF', 'ISK', 'ILS', 'LVL',
-        'CHF', 'NOK', 'PLN', 'SEK', 'TRY', 'GBP', )
+        'CHF', 'NOK', 'PLN', 'SEK', 'TRY', 'GBP', 'USD', )
 
     def get_gateway_url(self, request):
         return reverse('getpaid-paymill-authorization', kwargs={'pk' : self.payment.pk}), "GET", {}


### PR DESCRIPTION
USD was not listed as a supported currency in the init file. This was causing 403 Forbidden errors which were hard to debug, because the Paymill backend simply didn't show up in the payment form and the only error was about unsupported backend.