### PR TITLE
Added note about gateway urls in django backend in documentation

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -341,6 +341,7 @@ Optional keys:
 
 **gateway_url**
     You may want to change this to use dotpay testing account; default: ``https://ssl.dotpay.eu/``
+    if Your id is 5 digits long, You can leave it as it is. New id's are working with gateway ``https://ssl.dotpay.pl/``
     
 
 

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -341,8 +341,11 @@ Optional keys:
 
 **gateway_url**
     You may want to change this to use dotpay testing account; default: ``https://ssl.dotpay.eu/``
-    if Your id is 5 digits long, You can leave it as it is. New id's are working with gateway ``https://ssl.dotpay.pl/``
-    
+
+        .. warning::
+            Dotpay has strange policy regarding to gateway urls. It appears, that new accounts use ``https://ssl.dotpay.pl/``,
+            but old accounts, that have 5-digit long id's, should still use old gateway ``https://ssl.dotpay.eu/``. For reasons
+            of this behaviour You need to contact dotpay support.
 
 
 


### PR DESCRIPTION
I had chat with dotpay support recently, based on which I'm attaching short note to documentation.