### PR TITLE
Django 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   - DJANGO_VERSION=1.6
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8.3
+  - DJANGO_VERSION=1.8.5
+  - DJANGO_VERSION=1.9b1
 # command to install dependencies
 install: 
   - "pip install -q Django==$DJANGO_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
   - "3.4"
 env:
-  - DJANGO_VERSION=1.6
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8.3
   - DJANGO_VERSION=1.8.5

--- a/getpaid/__init__.py
+++ b/getpaid/__init__.py
@@ -1,4 +1,2 @@
-#noinspection PyUnresolvedReferences
-from .models import register_to_payment
-
+from .utils import register_to_payment
 default_app_config = 'getpaid.apps.Config'

--- a/getpaid/apps.py
+++ b/getpaid/apps.py
@@ -1,6 +1,5 @@
 from django.apps import AppConfig
 
-
 class Config(AppConfig):
     name = 'getpaid'
     verbose_name = 'application getpaid'

--- a/getpaid/backends/dotpay/__init__.py
+++ b/getpaid/backends/dotpay/__init__.py
@@ -61,7 +61,7 @@ class PaymentProcessor(PaymentProcessorBase):
         if params['id'] != int(PaymentProcessor.get_backend_setting('id')):
             return u'ID ERR'
 
-        from getpaid.models import Payment
+        from getpaid.utils import Payment
         try:
             payment = Payment.objects.get(pk=int(params['control']))
         except (ValueError, Payment.DoesNotExist):

--- a/getpaid/backends/dotpay/views.py
+++ b/getpaid/backends/dotpay/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic.base import View
 from django.views.generic.detail import DetailView
 from getpaid.backends.dotpay import PaymentProcessor
-from getpaid.models import Payment
+from getpaid.utils import Payment
 
 logger = logging.getLogger('getpaid.backends.dotpay')
 

--- a/getpaid/backends/dummy/views.py
+++ b/getpaid/backends/dummy/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic.edit import FormView
 from getpaid.backends.dummy import PaymentProcessor
 from getpaid.backends.dummy.forms import DummyQuestionForm
-from getpaid.models import Payment
+from getpaid.utils import Payment
 
 
 class DummyAuthorizationView(FormView):

--- a/getpaid/backends/epaydk/__init__.py
+++ b/getpaid/backends/epaydk/__init__.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language_from_request
 from django.contrib.sites.models import Site
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.six.moves.urllib.parse import urlparse, urlunparse,\
     parse_qsl, urlencode, quote
@@ -238,7 +238,7 @@ class PaymentProcessor(PaymentProcessorBase):
         """
         Payment was confirmed.
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         with commit_on_success_or_atomic():
             payment = Payment.objects.get(id=params['orderid'])
             assert payment.status == 'accepted_for_proc',\
@@ -256,7 +256,7 @@ class PaymentProcessor(PaymentProcessorBase):
         """
         Payment was accepted into the queue for processing.
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         with commit_on_success_or_atomic():
             payment = Payment.objects.get(id=payment_id)
             assert payment.status == 'in_progress',\
@@ -268,7 +268,7 @@ class PaymentProcessor(PaymentProcessorBase):
         """
         Payment was cancelled.
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         with commit_on_success_or_atomic():
             payment = Payment.objects.get(id=payment_id)
             payment.change_status('cancelled')

--- a/getpaid/backends/epaydk/views.py
+++ b/getpaid/backends/epaydk/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.generic import View
 from django.shortcuts import redirect, get_object_or_404
 from django.forms import ValidationError
-from django.db.models.loading import get_model
+from django.apps import apps
 
 
 from getpaid.backends.epaydk import PaymentProcessor
@@ -72,7 +72,7 @@ class AcceptView(View):
     http_method_names = ['get', ]
 
     def get(self, request):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         form = EpaydkOnlineForm(request.GET)
         if not form.is_valid():
             logger.debug("EpaydkOnlineForm not valid")
@@ -121,7 +121,7 @@ class CancelView(View):
         Receives params: orderid as int payment id and error as negative int.
         @warning: epay.dk doesn't send hash param!
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         form = EpaydkCancellForm(request.GET)
         if not form.is_valid():
             logger.debug("EpaydkCancellForm not valid")

--- a/getpaid/backends/moip/__init__.py
+++ b/getpaid/backends/moip/__init__.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import logging
 import datetime
 from django.core.urlresolvers import reverse
-from django.db.models import get_model
+from django.apps import apps
 from django.utils.timezone import utc
 import requests
 import time
@@ -94,7 +94,7 @@ class PaymentProcessor(PaymentProcessorBase):
 
     @staticmethod
     def process_notification(params):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         try:
             payment = Payment.objects.get(pk=int(params["id"].split("-")[0]))
         except Payment.DoesNotExist:

--- a/getpaid/backends/moip/views.py
+++ b/getpaid/backends/moip/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, Http404, HttpResponseRedirect
 from django.views.generic import DetailView
 from django.views.generic.base import View
 from getpaid.backends.moip import PaymentProcessor
-from getpaid.models import Payment
+from getpaid.utils import Payment
 
 logger = logging.getLogger('getpaid.backends.moip')
 

--- a/getpaid/backends/paymill/views.py
+++ b/getpaid/backends/paymill/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic.edit import FormView
 from . import PaymentProcessor
 from .forms import PaymillForm
-from getpaid.models import Payment
+from getpaid.utils import Payment
 import pymill
 
 

--- a/getpaid/backends/payu/tasks.py
+++ b/getpaid/backends/payu/tasks.py
@@ -1,6 +1,6 @@
 import logging
 from celery.task.base import task
-from django.db.models.loading import get_model
+from django.apps import apps
 
 
 logger = logging.getLogger('getpaid.backends.payu')
@@ -8,7 +8,7 @@ logger = logging.getLogger('getpaid.backends.payu')
 
 @task(max_retries=50, default_retry_delay=2*60)
 def get_payment_status_task(payment_id, session_id):
-    Payment = get_model('getpaid', 'Payment')
+    Payment = apps.get_model('getpaid', 'Payment')
     try:
         payment = Payment.objects.get(pk=int(payment_id))
     except Payment.DoesNotExist:
@@ -21,7 +21,7 @@ def get_payment_status_task(payment_id, session_id):
 
 @task(max_retries=50, default_retry_delay=2 * 60)
 def accept_payment(payment_id, session_id):
-    Payment = get_model('getpaid', 'Payment')
+    Payment = apps.get_model('getpaid', 'Payment')
     try:
         payment = Payment.objects.get(pk=int(payment_id))
     except Payment.DoesNotExist:

--- a/getpaid/backends/payu/views.py
+++ b/getpaid/backends/payu/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic.base import View
 from django.views.generic.detail import DetailView
 from getpaid.backends.payu import PaymentProcessor
-from getpaid.models import Payment
+from getpaid.utils import Payment
 
 logger = logging.getLogger('getpaid.backends.payu')
 

--- a/getpaid/backends/przelewy24/tasks.py
+++ b/getpaid/backends/przelewy24/tasks.py
@@ -1,13 +1,13 @@
 import logging
 from celery.task.base import task
-from django.db.models.loading import get_model
+from django.apps import apps
 
 logger = logging.getLogger('getpaid.backends.przelewy24')
 
 
 @task
 def get_payment_status_task(payment_id, p24_session_id, p24_order_id, p24_kwota):
-    Payment = get_model('getpaid', 'Payment')
+    Payment = apps.get_model('getpaid', 'Payment')
     try:
         payment = Payment.objects.get(pk=int(payment_id))
     except Payment.DoesNotExist:

--- a/getpaid/backends/przelewy24/views.py
+++ b/getpaid/backends/przelewy24/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic.base import View
 from django.views.generic.detail import DetailView
 from getpaid.backends.przelewy24 import PaymentProcessor
-from getpaid.models import Payment
+from getpaid.utils import Payment
 
 logger = logging.getLogger('getpaid.backends.przelewy24')
 

--- a/getpaid/backends/transferuj/__init__.py
+++ b/getpaid/backends/transferuj/__init__.py
@@ -7,7 +7,7 @@ from django.utils import six
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.utils.timezone import utc
 from django.utils.translation import ugettext_lazy as _
 from getpaid import signals
@@ -60,7 +60,7 @@ class PaymentProcessor(PaymentProcessorBase):
             logger.warning('Got message with wrong id, %s' % str(params))
             return u'ID ERR'
 
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         try:
             payment = Payment.objects.select_related('order').get(pk=int(tr_crc))
         except (Payment.DoesNotExist, ValueError):

--- a/getpaid/backends/transferuj/views.py
+++ b/getpaid/backends/transferuj/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic.base import View
 from django.views.generic.detail import DetailView
 from getpaid.backends.transferuj import PaymentProcessor
-from getpaid.models import Payment
+from getpaid.utils import Payment
 
 logger = logging.getLogger('getpaid.backends.transferuj')
 

--- a/getpaid/forms.py
+++ b/getpaid/forms.py
@@ -9,8 +9,7 @@ from django.utils.encoding import force_text
 
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
-from getpaid.models import Order
-from .utils import get_backend_choices, import_name
+from .utils import get_backend_choices, import_name, Order
 
 
 class PaymentRadioInput(RadioChoiceInput):

--- a/getpaid/tests.py
+++ b/getpaid/tests.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 from collections import OrderedDict
 
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
@@ -103,7 +103,7 @@ class TransferujBackendTestCase(TestCase):
                                                                              '6a9e045010c27dfed24774b0afa37d0b'))
 
     def test_online_payment_ok(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -118,7 +118,7 @@ class TransferujBackendTestCase(TestCase):
         self.assertEqual(payment.amount_paid, Decimal('123.45'))
 
     def test_online_payment_ok_over(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -133,7 +133,7 @@ class TransferujBackendTestCase(TestCase):
         self.assertEqual(payment.amount_paid, Decimal('223.45'))
 
     def test_online_payment_partial(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -148,7 +148,7 @@ class TransferujBackendTestCase(TestCase):
         self.assertEqual(payment.amount_paid, Decimal('23.45'))
 
     def test_online_payment_failure(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -291,7 +291,7 @@ trans_sig:e4e981bfa780fa78fb077ca1f9295f2a
 
     @mock.patch("getpaid.backends.payu.urlopen", fake_payment_get_response_success)
     def test_payment_get_paid(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(pk=99, order=order, amount=order.total, currency=order.currency,
@@ -307,7 +307,7 @@ trans_sig:e4e981bfa780fa78fb077ca1f9295f2a
 
     @mock.patch("getpaid.backends.payu.urlopen", fake_payment_get_response_failure)
     def test_payment_get_failed(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(pk=98, order=order, amount=order.total, currency=order.currency,
@@ -362,7 +362,7 @@ class Przelewy24PaymentProcessorTestCase(TestCase):
 
     @mock.patch("getpaid.backends.przelewy24.urlopen", fake_przelewy24_payment_get_response_success)
     def test_get_payment_status_success(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test PLN order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(pk=191, order=order, amount=order.total, currency=order.currency,
@@ -380,7 +380,7 @@ class Przelewy24PaymentProcessorTestCase(TestCase):
     @mock.patch("getpaid.backends.przelewy24.urlopen",
                 fake_przelewy24_payment_get_response_success)
     def test_get_payment_status_success_partial(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test PLN order', total='123.45', currency='PLN')
         order.save()
 
@@ -399,7 +399,7 @@ class Przelewy24PaymentProcessorTestCase(TestCase):
 
     @mock.patch("getpaid.backends.przelewy24.urlopen", fake_przelewy24_payment_get_response_failed)
     def test_get_payment_status_failed(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test PLN order', total='123.45', currency='PLN')
         order.save()
 
@@ -421,7 +421,7 @@ class EpaydkBackendTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test DKK order', total='123.45', currency='DKK')
         order.save()
 
@@ -507,7 +507,7 @@ class EpaydkBackendTestCase(TestCase):
         expected_url = reverse('getpaid-success-fallback',
                                kwargs=dict(pk=self.test_payment.pk))
         self.assertRedirects(response, expected_url, 302, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'accepted_for_proc')
 
@@ -533,7 +533,7 @@ class EpaydkBackendTestCase(TestCase):
         response = self.client.get(url, data=params)
         self.assertEqual(response.content, b'OK')
         self.assertEqual(response.status_code, 200)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'paid')
 
@@ -556,7 +556,7 @@ class EpaydkBackendTestCase(TestCase):
         response = self.client.get(url, data=params)
         self.assertEqual(response.content, b'400 Bad Request')
         self.assertEqual(response.status_code, 400)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'new')
 
@@ -574,6 +574,6 @@ class EpaydkBackendTestCase(TestCase):
         expected = reverse('getpaid-failure-fallback',
                            kwargs=dict(pk=self.test_payment.pk))
         self.assertRedirects(response, expected, 302, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'cancelled')

--- a/getpaid/views.py
+++ b/getpaid/views.py
@@ -32,7 +32,7 @@ class NewPaymentView(FormView):
         raise Http404
 
     def form_valid(self, form):
-        from getpaid.models import Payment
+        from getpaid.utils import Payment
         try:
             order_additional_validation\
                 .send(sender=None, request=self.request,
@@ -73,7 +73,7 @@ class FallbackView(RedirectView):
     permanent = False
 
     def get_redirect_url(self, **kwargs):
-        from getpaid.models import Payment
+        from getpaid.utils import Payment
         self.payment = get_object_or_404(Payment, pk=self.kwargs['pk'])
 
         if self.success:

--- a/getpaid_test_project/getpaid_test_project/orders/templates/orders/order_detail.html
+++ b/getpaid_test_project/getpaid_test_project/orders/templates/orders/order_detail.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <html>
 <body>
 <h1>Order #{{ object.pk }}</h1>

--- a/getpaid_test_project/getpaid_test_project/orders/tests.py
+++ b/getpaid_test_project/getpaid_test_project/orders/tests.py
@@ -5,7 +5,7 @@ when you run "manage.py test".
 Replace this with more appropriate tests for your application.
 """
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.forms import ValidationError
 from django.test import TestCase
 from django.test.client import Client
@@ -34,7 +34,7 @@ class OrderTest(TestCase):
                                      'backend': 'getpaid.backends.dummy'}
         )
         self.assertEqual(response.status_code, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         payment = Payment.objects.get(order=order.pk)
         self.assertEqual(payment.backend, 'getpaid.backends.dummy')
         self.assertEqual(payment.amount, order.total)
@@ -55,7 +55,7 @@ class OrderTest(TestCase):
                                      'backend': 'getpaid.backends.payu'}
         )
         self.assertEqual(response.status_code, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         payment = Payment.objects.get(order=order.pk)
         self.assertEqual(payment.backend, 'getpaid.backends.payu')
         self.assertEqual(payment.amount, order.total)

--- a/getpaid_test_project/pip.req
+++ b/getpaid_test_project/pip.req
@@ -4,7 +4,7 @@ celery
 django-celery
 mock
 python-dateutil
-django-nose==1.4
+django-nose==1.4.2
 nose==1.3.7
 coverage==3.7.1
 yanc


### PR DESCRIPTION
I've done some changes to make django-getpaid compatible with django 1.9. This is mainly concerning the removal of the `django.models.loading` module in favor of the application loading framework introduced in django 1.7`. This breaks django 1.6 support, but I would argue this is the right choice since extended support for django 1.6 stopped April 1, 2015, and django 1.8 being the most recent LTS release.