### PR TITLE
Django 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
   - "2.7"
   - "3.4"
 env:
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8.6
+  - DJANGO_VERSION=1.7.11
+  - DJANGO_VERSION=1.8.8
+  - DJANGO_VERSION=1.9.1
 # command to install dependencies
 install: 
   - "pip install -q Django==$DJANGO_VERSION"

--- a/getpaid/__init__.py
+++ b/getpaid/__init__.py
@@ -1,4 +1,9 @@
-#noinspection PyUnresolvedReferences
-from .models import register_to_payment
-
 default_app_config = 'getpaid.apps.Config'
+
+
+def register_to_payment(*args, **kwargs):
+    """
+    Thin proxy for actual register_to_payment to prevent uncontrolled early loading of models directory.
+    """
+    from . import models
+    return models.register_to_payment(*args, **kwargs)

--- a/getpaid/backends/epaydk/__init__.py
+++ b/getpaid/backends/epaydk/__init__.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language_from_request
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.six.moves.urllib.parse import urlencode
 from getpaid.utils import get_domain
@@ -224,7 +224,7 @@ class PaymentProcessor(PaymentProcessorBase):
         """
         Payment was confirmed.
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         with commit_on_success_or_atomic():
             payment = Payment.objects.get(id=params['orderid'])
             assert payment.status == 'accepted_for_proc',\
@@ -241,7 +241,7 @@ class PaymentProcessor(PaymentProcessorBase):
         """
         Payment was accepted into the queue for processing.
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         with commit_on_success_or_atomic():
             payment = Payment.objects.get(id=payment_id)
             assert payment.status == 'in_progress',\
@@ -253,7 +253,7 @@ class PaymentProcessor(PaymentProcessorBase):
         """
         Payment was cancelled.
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         with commit_on_success_or_atomic():
             payment = Payment.objects.get(id=payment_id)
             payment.change_status('cancelled')

--- a/getpaid/backends/epaydk/views.py
+++ b/getpaid/backends/epaydk/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.generic import View
 from django.shortcuts import redirect, get_object_or_404
 from django.forms import ValidationError
-from django.db.models.loading import get_model
+from django.apps import apps
 
 
 from getpaid.backends.epaydk import PaymentProcessor
@@ -72,7 +72,7 @@ class AcceptView(View):
     http_method_names = ['get', ]
 
     def get(self, request):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         form = EpaydkOnlineForm(request.GET)
         if not form.is_valid():
             logger.debug("EpaydkOnlineForm not valid")
@@ -121,7 +121,7 @@ class CancelView(View):
         Receives params: orderid as int payment id and error as negative int.
         @warning: epay.dk doesn't send hash param!
         """
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         form = EpaydkCancellForm(request.GET)
         if not form.is_valid():
             logger.debug("EpaydkCancellForm not valid")

--- a/getpaid/backends/moip/__init__.py
+++ b/getpaid/backends/moip/__init__.py
@@ -2,8 +2,9 @@
 from decimal import Decimal
 import logging
 import datetime
+
+from django.apps import apps
 from django.core.urlresolvers import reverse
-from django.db.models import get_model
 from django.utils.timezone import utc
 import requests
 import time
@@ -94,7 +95,7 @@ class PaymentProcessor(PaymentProcessorBase):
 
     @staticmethod
     def process_notification(params):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         try:
             payment = Payment.objects.get(pk=int(params["id"].split("-")[0]))
         except Payment.DoesNotExist:

--- a/getpaid/backends/payu/tasks.py
+++ b/getpaid/backends/payu/tasks.py
@@ -1,6 +1,6 @@
 import logging
 from celery.task.base import get_task_logger, task
-from django.db.models.loading import get_model
+from django.apps import apps
 
 
 logger = logging.getLogger('getpaid.backends.payu')
@@ -9,7 +9,7 @@ task_logger = get_task_logger('getpaid.backends.payu')
 
 @task(max_retries=50, default_retry_delay=2*60)
 def get_payment_status_task(payment_id, session_id):
-    Payment = get_model('getpaid', 'Payment')
+    Payment = apps.get_model('getpaid', 'Payment')
     try:
         payment = Payment.objects.get(pk=int(payment_id))
     except Payment.DoesNotExist:
@@ -22,7 +22,7 @@ def get_payment_status_task(payment_id, session_id):
 
 @task(max_retries=50, default_retry_delay=2 * 60)
 def accept_payment(payment_id, session_id):
-    Payment = get_model('getpaid', 'Payment')
+    Payment = apps.get_model('getpaid', 'Payment')
     try:
         payment = Payment.objects.get(pk=int(payment_id))
     except Payment.DoesNotExist:

--- a/getpaid/backends/przelewy24/tasks.py
+++ b/getpaid/backends/przelewy24/tasks.py
@@ -1,13 +1,13 @@
 import logging
 from celery.task.base import task
-from django.db.models.loading import get_model
+from django.apps import apps
 
 logger = logging.getLogger('getpaid.backends.przelewy24')
 
 
 @task
 def get_payment_status_task(payment_id, p24_session_id, p24_order_id, p24_kwota):
-    Payment = get_model('getpaid', 'Payment')
+    Payment = apps.get_model('getpaid', 'Payment')
     try:
         payment = Payment.objects.get(pk=int(payment_id))
     except Payment.DoesNotExist:

--- a/getpaid/backends/transferuj/__init__.py
+++ b/getpaid/backends/transferuj/__init__.py
@@ -5,7 +5,7 @@ from six.moves.urllib.parse import urlencode
 from django.utils.six import text_type
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from getpaid import signals
@@ -59,7 +59,7 @@ class PaymentProcessor(PaymentProcessorBase):
             logger.warning('Got message with wrong id, %s' % str(params))
             return u'ID ERR'
 
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         try:
             payment = Payment.objects.select_related('order').get(pk=int(tr_crc))
         except (Payment.DoesNotExist, ValueError):

--- a/getpaid/models.py
+++ b/getpaid/models.py
@@ -152,5 +152,5 @@ def register_to_payment(order_class, **kwargs):
     backend_models_modules = import_backend_modules('models')
     for backend_name, models_module in backend_models_modules.items():
         for model in models_module.build_models(Payment):
-            apps.register_model(backend_name, module)
+            apps.register_model(backend_name, model)
     return Payment

--- a/getpaid/models.py
+++ b/getpaid/models.py
@@ -1,5 +1,7 @@
 import sys
 from datetime import datetime
+
+from django.apps import apps
 from django.db import models
 from django.utils import six
 from django.utils.timezone import utc
@@ -124,10 +126,6 @@ class PaymentFactory(models.Model, AbstractMixin):
         self.change_status('failed')
 
 
-from django.db.models.loading import cache as app_cache, register_models
-#from utils import import_backend_modules
-
-
 def register_to_payment(order_class, **kwargs):
     """
     A function for registering unaware order class to ``getpaid``. This will
@@ -152,6 +150,7 @@ def register_to_payment(order_class, **kwargs):
     # Now build models for backends
 
     backend_models_modules = import_backend_modules('models')
-    for backend_name, models in backend_models_modules.items():
-        app_cache.register_models(backend_name, *models.build_models(Payment))
+    for backend_name, models_module in backend_models_modules.items():
+        for model in models_module.build_models(Payment):
+            apps.register_model(backend_name, module)
     return Payment

--- a/getpaid/utils.py
+++ b/getpaid/utils.py
@@ -3,13 +3,15 @@ import sys
 from collections import OrderedDict
 from importlib import import_module
 
+from django.apps import apps
 from django.conf import settings
 from django.utils import six
 from django.core.urlresolvers import reverse
+from django.utils.functional import SimpleLazyObject
 from django.utils.six.moves.urllib.parse import parse_qsl
-from django.contrib.sites.models import Site
 import django
 
+Site = SimpleLazyObject(lambda: apps.get_model('sites.Site'))
 
 if six.PY3:
     unicode = str

--- a/getpaid_test_project/getpaid_test_project/orders/templates/orders/order_detail.html
+++ b/getpaid_test_project/getpaid_test_project/orders/templates/orders/order_detail.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <html>
 <body>
 <h1>Order #{{ object.pk }}</h1>

--- a/getpaid_test_project/getpaid_test_project/orders/tests/test_epaydk.py
+++ b/getpaid_test_project/getpaid_test_project/orders/tests/test_epaydk.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
@@ -26,7 +26,7 @@ class EpaydkBackendTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test DKK order', total='123.45', currency='DKK')
         order.save()
 
@@ -112,7 +112,7 @@ class EpaydkBackendTestCase(TestCase):
         expected_url = reverse('getpaid-success-fallback',
                                kwargs=dict(pk=self.test_payment.pk))
         self.assertRedirects(response, expected_url, 302, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'accepted_for_proc')
 
@@ -138,7 +138,7 @@ class EpaydkBackendTestCase(TestCase):
         response = self.client.get(url, data=params)
         self.assertEqual(response.content, b'OK')
         self.assertEqual(response.status_code, 200)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'paid')
 
@@ -161,7 +161,7 @@ class EpaydkBackendTestCase(TestCase):
         response = self.client.get(url, data=params)
         self.assertEqual(response.content, b'400 Bad Request')
         self.assertEqual(response.status_code, 400)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'new')
 
@@ -179,6 +179,6 @@ class EpaydkBackendTestCase(TestCase):
         expected = reverse('getpaid-failure-fallback',
                            kwargs=dict(pk=self.test_payment.pk))
         self.assertRedirects(response, expected, 302, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         actual = Payment.objects.get(id=self.test_payment.id)
         self.assertEqual(actual.status, 'cancelled')

--- a/getpaid_test_project/getpaid_test_project/orders/tests/test_order.py
+++ b/getpaid_test_project/getpaid_test_project/orders/tests/test_order.py
@@ -5,7 +5,7 @@ when you run "manage.py test".
 Replace this with more appropriate tests for your application.
 """
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.forms import ValidationError
 from django.test import TestCase
 from django.test.client import Client
@@ -35,7 +35,7 @@ class OrderTest(TestCase):
         data = {'order': order.pk, 'backend': 'getpaid.backends.dummy'}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         payment = Payment.objects.get(order=order.pk)
         self.assertEqual(payment.backend, 'getpaid.backends.dummy')
         self.assertEqual(payment.amount, order.total)
@@ -55,7 +55,7 @@ class OrderTest(TestCase):
                                      'backend': 'getpaid.backends.payu'}
         )
         self.assertEqual(response.status_code, 302)
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         payment = Payment.objects.get(order=order.pk)
         self.assertEqual(payment.backend, 'getpaid.backends.payu')
         self.assertEqual(payment.amount, order.total)

--- a/getpaid_test_project/getpaid_test_project/orders/tests/test_payu.py
+++ b/getpaid_test_project/getpaid_test_project/orders/tests/test_payu.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 
 from django.core.urlresolvers import reverse
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.test import TestCase
 from django.test.client import Client
 from django.utils.six.moves.urllib.parse import urlparse, parse_qs, \
@@ -153,7 +153,7 @@ trans_sig:e4e981bfa780fa78fb077ca1f9295f2a
     @mock.patch("getpaid.backends.payu.Request", autospec=True)
     @mock.patch("getpaid.backends.payu.urlopen", fake_payment_get_response_success)
     def test_payment_get_paid(self, mock_Request):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(pk=99, order=order, amount=order.total, currency=order.currency,
@@ -181,7 +181,7 @@ trans_sig:e4e981bfa780fa78fb077ca1f9295f2a
 
     @mock.patch("getpaid.backends.payu.urlopen", fake_payment_get_response_failure)
     def test_payment_get_failed(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(pk=98, order=order, amount=order.total, currency=order.currency,

--- a/getpaid_test_project/getpaid_test_project/orders/tests/test_przelewy24.py
+++ b/getpaid_test_project/getpaid_test_project/orders/tests/test_przelewy24.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.test import TestCase
 from django.utils.six.moves.urllib.parse import urlparse, parse_qs, \
     parse_qsl, urlencode
@@ -58,7 +58,7 @@ class Przelewy24PaymentProcessorTestCase(TestCase):
 
     @mock.patch("getpaid.backends.przelewy24.urlopen", fake_przelewy24_payment_get_response_success)
     def test_get_payment_status_success(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test PLN order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(pk=191, order=order, amount=order.total, currency=order.currency,
@@ -76,7 +76,7 @@ class Przelewy24PaymentProcessorTestCase(TestCase):
     @mock.patch("getpaid.backends.przelewy24.urlopen",
                 fake_przelewy24_payment_get_response_success)
     def test_get_payment_status_success_partial(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test PLN order', total='123.45', currency='PLN')
         order.save()
 
@@ -95,7 +95,7 @@ class Przelewy24PaymentProcessorTestCase(TestCase):
 
     @mock.patch("getpaid.backends.przelewy24.urlopen", fake_przelewy24_payment_get_response_failed)
     def test_get_payment_status_failed(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test PLN order', total='123.45', currency='PLN')
         order.save()
 

--- a/getpaid_test_project/getpaid_test_project/orders/tests/test_transferuj.py
+++ b/getpaid_test_project/getpaid_test_project/orders/tests/test_transferuj.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from mock import Mock, patch
 from hashlib import md5
 
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import six
@@ -91,7 +91,7 @@ class TransferujBackendTestCase(TestCase):
                                                                              '6a9e045010c27dfed24774b0afa37d0b'))
 
     def test_online_payment_ok(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -106,7 +106,7 @@ class TransferujBackendTestCase(TestCase):
         self.assertEqual(payment.amount_paid, Decimal('123.45'))
 
     def test_online_payment_ok_over(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -121,7 +121,7 @@ class TransferujBackendTestCase(TestCase):
         self.assertEqual(payment.amount_paid, Decimal('223.45'))
 
     def test_online_payment_partial(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')
@@ -136,7 +136,7 @@ class TransferujBackendTestCase(TestCase):
         self.assertEqual(payment.amount_paid, Decimal('23.45'))
 
     def test_online_payment_failure(self):
-        Payment = get_model('getpaid', 'Payment')
+        Payment = apps.get_model('getpaid', 'Payment')
         order = Order(name='Test EUR order', total='123.45', currency='PLN')
         order.save()
         payment = Payment(order=order, amount=order.total, currency=order.currency, backend='getpaid.backends.payu')

--- a/getpaid_test_project/getpaid_test_project/settings.py
+++ b/getpaid_test_project/getpaid_test_project/settings.py
@@ -141,7 +141,7 @@ INSTALLED_APPS = (
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
 
-    # 'djcelery.transport',
+    'djcelery',
     'kombu.transport.django',
 
     'getpaid',

--- a/getpaid_test_project/requirements.txt
+++ b/getpaid_test_project/requirements.txt
@@ -4,7 +4,7 @@ celery
 django-celery
 mock==1.3.0
 python-dateutil
-django-nose==1.4
+django-nose==1.4.3
 nose==1.3.7
 coverage==3.7.1
 yanc


### PR DESCRIPTION
Shallow changes to fully adjust application to more strict `django.apps` framework in Django 1.9, dropped support for 1.6 as it was last release without `django.apps`.