### PR TITLE
Fix Django 1.10 Warning (form_class default value)

### DIFF
--- a/getpaid/views.py
+++ b/getpaid/views.py
@@ -20,7 +20,7 @@ class NewPaymentView(FormView):
     form_class = PaymentMethodForm
     template_name = "getpaid/payment_post_form.html"
 
-    def get_form(self, form_class):
+    def get_form(self, form_class=PaymentMethodForm):
         self.currency = self.kwargs['currency']
         return form_class(self.currency, **self.get_form_kwargs())
 


### PR DESCRIPTION
RemovedInDjango110Warning: `getpaid.views.NewPaymentView.get_form` method must define a default value for its `form_class` argument.