### PR TITLE
Fix missing permitted methods

### DIFF
--- a/getpaid/views.py
+++ b/getpaid/views.py
@@ -31,7 +31,7 @@ class NewPaymentView(FormView):
         This view operates only on POST requests from order view where
         you select payment method
         """
-        return http.HttpResponseNotAllowed()
+        return http.HttpResponseNotAllowed(['POST'])
 
     def form_valid(self, form):
         from getpaid.models import Payment


### PR DESCRIPTION
`django.http.HttpResponseNotAllowed` constructor requires permitted methods argument as described in docs: https://docs.djangoproject.com/en/1.11/ref/request-response/#django.http.HttpResponseNotAllowed